### PR TITLE
Add listen port and allow httpd.conf to be writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN mkdir -p ${HOME}/htdocs && \
 
 COPY httpd.conf ${HOME}/httpd.conf
 
-EXPOSE 8080
 
 # Copy into place S2I builder scripts, the run script, and label the Docker
 # image so that the 's2i' program knows where to find them.
@@ -47,7 +46,6 @@ COPY run ${HOME}/run
 
 LABEL io.k8s.description="S2I builder for hosting files with Apache HTTPD server" \
       io.k8s.display-name="Apache HTTPD Server" \
-      io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,httpd" \
       io.openshift.s2i.scripts-url="image://${HOME}/s2i/bin"
 
@@ -61,6 +59,7 @@ RUN chown -R 1001:0 /opt/app-root && \
 # Ensure container runs as non root account from its home directory.
 
 WORKDIR ${HOME}
+RUN chmod go+w ${HOME}/httpd.conf
 
 USER 1001
 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,11 @@ In this case this will create a Docker-formatted image called ``myhttpdsite``. Y
 ```
 docker run --rm -p 8080:8080 myhttpdsite
 ```
+
+You can also change default port by setting the LISTEN_PORT environment variable
+```
+LISTEN_PORT=9000 docker run --rm -p $LISTEN_PORT:$LISTEN_PORT myhttpdsite
+```
+
+
+

--- a/run
+++ b/run
@@ -4,6 +4,10 @@
 
 source scl_source enable httpd24
 
-# Ensure we run the Apache HTTPD server as process ID 1 and in foreground.
+# Add Listen port if defined
+if [[ ! -z "$LISTEN_PORT" ]]; then
+  echo "Listen $LISTEN_PORT" >> ${HOME}/httpd.conf
+fi
 
+# Ensure we run the Apache HTTPD server as process ID 1 and in foreground.
 exec httpd -DFOREGROUND


### PR DESCRIPTION
Since this image is used by getwarped/site-maintenance and that route-backends uses the same port for all backends, it is very convenient to have the ability to use additional or alternative ports
